### PR TITLE
Add note about iviewer

### DIFF
--- a/docs/data-management.rst
+++ b/docs/data-management.rst
@@ -568,7 +568,7 @@ Previously created Shares can still be viewed in the ``Shares`` tab |image6| abo
  - You will also be sharing the data with all the other members of that group
 
 .. note::
-    Shares were never supported by OMERO.iviewer. In case OMERO.iviewer is installed on your server and is set as a default viewer, it is not possible for the users with whom the images inside a historical Share are shared to view these in a Full viewer.
+    Shares were never supported by OMERO.iviewer. If OMERO.iviewer is installed on your server and is set as a default viewer, then, for the Share participants, it is not possible to view images inside a historical Share in any Full viewer.
 
 .. |image0| image:: images/management1.png
    :height: 3.4592in

--- a/docs/data-management.rst
+++ b/docs/data-management.rst
@@ -568,7 +568,7 @@ Previously created Shares can still be viewed in the ``Shares`` tab |image6| abo
  - You will also be sharing the data with all the other members of that group
 
 .. note::
-    Shares were never supported by OMERO.iviewer. If OMERO.iviewer is installed on your server and is set as a default viewer, then, for the Share participants, it is not possible to view images inside a historical Share in any Full viewer.
+    Shares were never supported by OMERO.iviewer. If OMERO.iviewer is installed on your server and is set as a default viewer, then users with permissions to access the data in the Share cannot view images in any Full viewer.
 
 .. |image0| image:: images/management1.png
    :height: 3.4592in

--- a/docs/data-management.rst
+++ b/docs/data-management.rst
@@ -568,7 +568,7 @@ Previously created Shares can still be viewed in the ``Shares`` tab |image6| abo
  - You will also be sharing the data with all the other members of that group
 
 .. note::
-    Shares were never supported by OMERO.iviewer. If OMERO.iviewer is installed on your server and is set as a default viewer, then users with permissions to access the data in the Share cannot view images in any Full viewer.
+    Shares were never supported by OMERO.iviewer. If OMERO.iviewer or other viewer which does not support Shares is installed on your server and is set as a default viewer, then users with permissions to access the data in the Share cannot view images in any Full viewer.
 
 .. |image0| image:: images/management1.png
    :height: 3.4592in

--- a/docs/data-management.rst
+++ b/docs/data-management.rst
@@ -567,6 +567,9 @@ Previously created Shares can still be viewed in the ``Shares`` tab |image6| abo
  - You need to already be in a non-private group with the user you wish to share with
  - You will also be sharing the data with all the other members of that group
 
+.. note::
+    Shares were never supported by OMERO.iviewer. In case OMERO.iviewer is installed on your server and is set as a default viewer, it is not possible for the users with whom the images inside a historical Share are shared to view these in a Full viewer.
+
 .. |image0| image:: images/management1.png
    :height: 3.4592in
 .. |image1| image:: images/management2.png


### PR DESCRIPTION
as noticed when working on the last testing of Shares, the historical Shares cannot be viewed in full viewer by the user with whom the share is intended if iviewer is installed as default viewer.

This PR adds a note about it into the guide.

cc @sbesson @jburel 