### PR TITLE
Reformat description

### DIFF
--- a/docs/annotate.rst
+++ b/docs/annotate.rst
@@ -3,28 +3,20 @@ Annotate Data and Filter using Annotations
 
 There are several ways to add annotations to objects in OMERO. Here, addition and filtering of annotations using OMERO.web is described. You can add annotations using the OMERO.web interface to any object(s) that you can select in the left-hand-side tree or central pane, this means ``Project``, ``Dataset``, ``Image``, ``Screen``, ``Plate`` and ``Well``.
 
+
 Description
 -----------
 
-We will show:
-
--  How to annotate Images, Datasets and Projects with:
-
-   -  Tags
-
-   -  Key-Value Pairs
-
-   -  File Attachments
-
-   -  Ratings
-
--  How to filter thumbnails in the central pane of OMERO.web for:
-
-   -  Tags
-
-   -  Key-Value Pairs
-
-   -  Ratings
+| We will show:
+|  How to annotate Images, Datasets and Projects with:
+|    - Tags
+|    - Key-Value Pairs
+|    - File Attachments
+|    - Ratings
+|  How to filter thumbnails in the central pane of OMERO.web for:
+|    - Tags
+|    - Key-Value Pairs
+|    - Ratings
 
 Setup
 -----

--- a/docs/annotate.rst
+++ b/docs/annotate.rst
@@ -7,16 +7,23 @@ There are several ways to add annotations to objects in OMERO. Here, addition an
 Description
 -----------
 
-| We will show:
-|  How to annotate Images, Datasets and Projects with:
-|    - Tags
-|    - Key-Value Pairs
-|    - File Attachments
-|    - Ratings
-|  How to filter thumbnails in the central pane of OMERO.web for:
-|    - Tags
-|    - Key-Value Pairs
-|    - Ratings
+We will show:
+  - How to annotate Images, Datasets and Projects with:
+
+     - Tags
+
+     - Key-Value Pairs
+
+     - File Attachments
+
+     - Ratings
+  - How to filter thumbnails in the central pane of OMERO.web for:
+
+     - Tags
+
+     - Key-Value Pairs
+
+     - Ratings
 
 Setup
 -----


### PR DESCRIPTION
Noticed during the prep of the upcoming outreach event https://docs.google.com/document/d/1NAWJjNU-La9tk9cO6nnMTRREOZ4bi0S39Hkjj6PeYuQ/edit#

The description of the https://omero-guides.readthedocs.io/projects/introduction/en/latest/annotate.html is barely readable because of the formatting issues (the bullet points are not respected).

This PR suggests an Line block approach. See build at https://omero-guides--25.org.readthedocs.build/projects/introduction/en/25/annotate.html - much more readable imho. If we are happy with this formatting, I can propagate it to other guides.

Before:

![Screenshot 2023-02-08 at 17 17 02](https://user-images.githubusercontent.com/2478303/217603963-56037b88-57c2-4323-97dc-d6c756905f61.png)



After:

![Screenshot 2023-02-08 at 17 17 14](https://user-images.githubusercontent.com/2478303/217603947-2759ace1-cf5a-4e2d-92ba-238d30d6f21e.png)
